### PR TITLE
1. "srs_hijack_io_is_never_timeout" function return value declared di…

### DIFF
--- a/src/app/htl_app_srs_hijack.cpp
+++ b/src/app/htl_app_srs_hijack.cpp
@@ -49,7 +49,7 @@ void srs_hijack_io_destroy(srs_hijack_io_t ctx)
     delete skt;
 }
 
-int srs_hijack_io_create_socket(srs_hijack_io_t /*ctx*/, srs_rtmp_t /*owner*/)
+int srs_hijack_io_create_socket(srs_hijack_io_t /*ctx*/)//, srs_rtmp_t /*owner*/)
 {
     return ERROR_SUCCESS;
 }

--- a/src/app/srs_librtmp.h
+++ b/src/app/srs_librtmp.h
@@ -1036,7 +1036,7 @@ typedef void* srs_hijack_io_t;
     * whether the timeout is never timeout.
     * @return 0, success; otherswise, failed.
     */
-    extern bool srs_hijack_io_is_never_timeout(srs_hijack_io_t ctx, int64_t timeout_us);
+    extern int srs_hijack_io_is_never_timeout(srs_hijack_io_t ctx, int64_t timeout_us);
     /**
     * read fully, fill the buf exactly size bytes.
     * @return 0, success; otherswise, failed.


### PR DESCRIPTION
…fferently

=> error: ambiguating new declaration of ‘int srs_hijack_io_is_never_timeout(srs_hijack_io_t, int64_t)’

2. The difference between "srs_hijack_io_create_socket" function declarations and usage parts: function parameter
=> undefined reference to `srs_hijack_io_create_socket'